### PR TITLE
fix: soapAction should be fixed, not environment-specific

### DIFF
--- a/src/app/uitkeringen/UitkeringsApi.js
+++ b/src/app/uitkeringen/UitkeringsApi.js
@@ -11,7 +11,7 @@ class UitkeringsApi {
     async getUitkeringen(bsn) {
         const data = await this.client.requestData(this.endpoint, this.body(bsn), {
             'Content-type': 'text/xml',
-            'SoapAction': this.endpoint + '/getData'
+            'SoapAction': 'https://data-test.nijmegen.nl/mijnNijmegenData/getData'
         });
         console.log('Uitkerings api response: ');
         console.log(data.substring(0, 10));

--- a/test/__snapshots__/main.test.ts.snap
+++ b/test/__snapshots__/main.test.ts.snap
@@ -52,7 +52,7 @@ Object {
     },
     \\"build\\": {
       \\"commands\\": [
-        \\"cdk-assets --path \\\\\\"assembly-test-mijn-uitkering-api/testmijnuitkeringapiuitkeringsapi14A41BD4.assets.json\\\\\\" --verbose publish \\\\\\"b5db3f11804ba3e411ba96840c3a8856aa8e2af6495defacc2d00a70b74f0705:test-eu-west-1\\\\\\"\\"
+        \\"cdk-assets --path \\\\\\"assembly-test-mijn-uitkering-api/testmijnuitkeringapiuitkeringsapi14A41BD4.assets.json\\\\\\" --verbose publish \\\\\\"68c13ffca688bb157181ba7d58014ec84ea8a505bd5ab0f11d6087839ae3e0c8:test-eu-west-1\\\\\\"\\"
       ]
     }
   }


### PR DESCRIPTION
Uitkerings-api also had environment-specific soapAction. This should be static.
Fixes #72 #67 