### PR TITLE
feat: Self host fonts

### DIFF
--- a/src/shared/header.mustache
+++ b/src/shared/header.mustache
@@ -12,24 +12,25 @@
     <link rel="preconnect" 
           href="https://fonts.gstatic.com/" 
           crossorigin="anonymous">
+    
     <link rel="preload" 
           as="font" 
-          href="https://componenten.nijmegen.nl/v6.1.0/oranda_bold_bt.04c85cb2.woff2" 
+          href="/static/fonts/oranda_bold_bt.04c85cb2.woff2" 
           type="font/woff2"
           crossorigin="anonymous">
     <link rel="preload" 
           as="font" 
-          href="https://componenten.nijmegen.nl/v6.1.0/oranda_bold_bt.8e266873.woff" 
+          href="/static/fonts/oranda_bold_bt.8e266873.woff" 
           type="font/woff"
           crossorigin="anonymous">
     <link rel="preload" 
           as="font" 
-          href="https://componenten.nijmegen.nl/v6.1.0/oranda_bt.bde3d05f.woff2" 
+          href="/static/fonts/oranda_bt.bde3d05f.woff2" 
           type="font/woff2"
           crossorigin="anonymous">
     <link rel="preload" 
           as="font" 
-          href="https://componenten.nijmegen.nl/v6.1.0/oranda_bt.05235f9a.woff" 
+          href="/static/fonts/oranda_bt.05235f9a.woff" 
           type="font/woff"
           crossorigin="anonymous">
 

--- a/test/__snapshots__/main.test.ts.snap
+++ b/test/__snapshots__/main.test.ts.snap
@@ -52,7 +52,7 @@ Object {
     },
     \\"build\\": {
       \\"commands\\": [
-        \\"cdk-assets --path \\\\\\"assembly-test-mijn-uitkering-api/testmijnuitkeringapiuitkeringsapi14A41BD4.assets.json\\\\\\" --verbose publish \\\\\\"683497f087c14676cc4d01bd728b44af2334431e62073e73f466073829f18618:test-eu-west-1\\\\\\"\\"
+        \\"cdk-assets --path \\\\\\"assembly-test-mijn-uitkering-api/testmijnuitkeringapiuitkeringsapi14A41BD4.assets.json\\\\\\" --verbose publish \\\\\\"7449c9d22dd147ce26106385762869324abf34625d0538d5b07fccc22053c4ac:test-eu-west-1\\\\\\"\\"
       ]
     }
   }


### PR DESCRIPTION
Safari wil geen woff2 (wel de woff)-fonts laden zonder correcte CORS-headers. Zo te zien zet componenten.nijmegen.nl geen Access-Control-Allow-Origin header, dus laden de fonts niet. De .woff laden wel, maar worden niet gebruikt (soms?). Op nijmegen.nl wordt alles op het eigen domein gehost, en lopen ze hier dus niet (meer) tegenaan. Voor nu doen we hetzelfde.

Fixes https://github.com/GemeenteNijmegen/mijn-nijmegen/issues/88