### PR TITLE
feat: improve error handling

### DIFF
--- a/src/app/uitkeringen/ApiClient.js
+++ b/src/app/uitkeringen/ApiClient.js
@@ -7,7 +7,7 @@ class ApiClient {
     /**
      * Connects to API's. Use .requestData() to get the actual info
      * 
-     * @param {string} bsn BSN to request uitkeringsdata for
+     * @param {string} bsn BSN to request data for
      * @param {string|null} cert optional client cert, default is env variable MTLS_CLIENT_CERT
      * @param {string|null} key optional private key for client cert, default will get key from secret store
      * @param {string|null} ca optional root ca bundle to trust, default is env variable MTLS_ROOT_CA
@@ -34,15 +34,18 @@ class ApiClient {
      * @returns string private key
      */
      async getPrivateKey() {
-        if(!this.privatekey && process.env.MTLS_PRIVATE_KEY_ARN) { 
+        if(!this.privatekey) { 
+            if(!process.env.MTLS_PRIVATE_KEY_ARN) {
+                throw new Error ('no secret arn provided');
+            }
             const secretsManagerClient = new SecretsManagerClient();
             const command = new GetSecretValueCommand({ SecretId: process.env.MTLS_PRIVATE_KEY_ARN });
             const data = await secretsManagerClient.send(command);
             // Depending on whether the secret is a string or binary, one of these fields will be populated.
             if ('SecretString' in data) {
                 this.privatekey = data.SecretString
-            } else {      
-                console.log('no secret value found');
+            } else {
+                throw new Error('No secret value found');
             }
         }
         return this.privatekey;
@@ -64,7 +67,7 @@ class ApiClient {
 
     /**
      * Request data from the API. 
-     * @returns {string} XML string with uitkeringsdata
+     * @returns {string} api response
      */
     async requestData(endpoint, body, headers) {
         console.time('request to ' + endpoint);
@@ -85,19 +88,17 @@ class ApiClient {
                 // The request was made and the server responded with a status code
                 // that falls out of the range of 2xx
                 console.log('http status for ' + endpoint + ': ' + error.response.status);
-                return error.response.data;
-                console.debug('return response from ' + endpoint);
+                
               } else if (error.request) {
                 // The request was made but no response was received
                 // `error.request` is an instance of XMLHttpRequest in the browser and an instance of
                 // http.ClientRequest in node.js
                 console.error(error?.code);
-                return '';
               } else {
                 // Something happened in setting up the request that triggered an Error
-                console.error('Error', error.message);
-                return '';
+                console.error(error.message);
             }
+            throw new Error('Het ophalen van gegevens is misgegaan.');
         }
     }
 

--- a/src/app/uitkeringen/BrpApi.js
+++ b/src/app/uitkeringen/BrpApi.js
@@ -7,11 +7,19 @@ class BrpApi {
     }
 
     async getBrpData(bsn) {
-        let data = await this.client.requestData(this.endpoint, {"bsn": bsn}, {'Content-type': 'application/json'});
-        if(data?.Persoon) {
+        try {
+            let data = await this.client.requestData(this.endpoint, {"bsn": bsn}, {'Content-type': 'application/json'});
+            if(data?.Persoon) {
+                return data;
+            } else {
+                throw new Error('Er konden geen persoonsgegevens opgehaald worden.');
+            }
+        } catch (error) {
+            const data = {
+                'error' : error.message
+            }
             return data;
         }
-        return false;
     }
 }
 

--- a/src/app/uitkeringen/UitkeringsApi.js
+++ b/src/app/uitkeringen/UitkeringsApi.js
@@ -9,20 +9,29 @@ class UitkeringsApi {
     }
 
     async getUitkeringen(bsn) {
-        const data = await this.client.requestData(this.endpoint, this.body(bsn), {
-            'Content-type': 'text/xml',
-            'SoapAction': 'https://data-test.nijmegen.nl/mijnNijmegenData/getData'
-        });
-        console.log('Uitkerings api response: ');
-        console.log(data.substring(0, 10));
-        const object = await xml2js.parseStringPromise(data);
-        const uitkeringsRows =  this.mapUitkeringsRows(object);
-        let uitkeringen = this.mapUitkering(uitkeringsRows);
-        if(uitkeringen) {
-            uitkeringen = this.addFieldsByName(uitkeringen);
-            return uitkeringen;
+        try {
+            const data = await this.client.requestData(this.endpoint, this.body(bsn), {
+                'Content-type': 'text/xml',
+                'SoapAction': 'https://data-test.nijmegen.nl/mijnNijmegenData/getData'
+            });
+            console.log('Uitkerings api response: ');
+            console.log(data.substring(0, 10));
+            const object = await xml2js.parseStringPromise(data);
+            const uitkeringsRows =  this.mapUitkeringsRows(object);
+            let uitkeringen = this.mapUitkering(uitkeringsRows);
+            if(uitkeringen) {
+                uitkeringen = this.addFieldsByName(uitkeringen);
+                console.debug(uitkeringen);
+                return uitkeringen;
+            }
+            return {'uitkeringen': []};
+        } catch (error) {
+            console.error(error);
+            const data = {
+                'error' : error.message
+            }
+            return data;
         }
-        return {'uitkeringen': []};
     }
 
     /**
@@ -79,6 +88,7 @@ class UitkeringsApi {
                 return obj;
             });
             uitkering.fieldsByName = fieldsByName;
+            uitkering.typetolower = uitkering.type.toLowerCase().replace(/\s+/g, '-');
         });
         return uitkeringen;
     }

--- a/src/app/uitkeringen/package-lock.json
+++ b/src/app/uitkeringen/package-lock.json
@@ -20,6 +20,7 @@
       },
       "devDependencies": {
         "@aws-sdk/types": "3.47.0",
+        "axios-mock-adapter": "^1.20.0",
         "dotenv": "^16.0.0",
         "jest-aws-client-mock": "0.0.24"
       }
@@ -994,6 +995,20 @@
         "follow-redirects": "^1.14.8"
       }
     },
+    "node_modules/axios-mock-adapter": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/axios-mock-adapter/-/axios-mock-adapter-1.20.0.tgz",
+      "integrity": "sha512-shZRhTjLP0WWdcvHKf3rH3iW9deb3UdKbdnKUoHmmsnBhVXN3sjPJM6ZvQ2r/ywgvBVQrMnjrSyQab60G1sr2w==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "is-blob": "^2.1.0",
+        "is-buffer": "^2.0.5"
+      },
+      "peerDependencies": {
+        "axios": ">= 0.9.0"
+      }
+    },
     "node_modules/bowser": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
@@ -1024,6 +1039,12 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
+    },
     "node_modules/fast-xml-parser": {
       "version": "3.19.0",
       "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.19.0.tgz",
@@ -1053,6 +1074,41 @@
         "debug": {
           "optional": true
         }
+      }
+    },
+    "node_modules/is-blob": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-blob/-/is-blob-2.1.0.tgz",
+      "integrity": "sha512-SZ/fTft5eUhQM6oF/ZaASFDEdbFVe89Imltn9uZr03wdKMcWNVYSMjQPFtg05QuNkt5l5c135ElvXEQG0rk4tw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/jest-aws-client-mock": {
@@ -1957,6 +2013,17 @@
         "follow-redirects": "^1.14.8"
       }
     },
+    "axios-mock-adapter": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/axios-mock-adapter/-/axios-mock-adapter-1.20.0.tgz",
+      "integrity": "sha512-shZRhTjLP0WWdcvHKf3rH3iW9deb3UdKbdnKUoHmmsnBhVXN3sjPJM6ZvQ2r/ywgvBVQrMnjrSyQab60G1sr2w==",
+      "dev": true,
+      "requires": {
+        "fast-deep-equal": "^3.1.3",
+        "is-blob": "^2.1.0",
+        "is-buffer": "^2.0.5"
+      }
+    },
     "bowser": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
@@ -1978,6 +2045,12 @@
       "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
       "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="
     },
+    "fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
+    },
     "fast-xml-parser": {
       "version": "3.19.0",
       "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.19.0.tgz",
@@ -1987,6 +2060,18 @@
       "version": "1.14.9",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
       "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w=="
+    },
+    "is-blob": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-blob/-/is-blob-2.1.0.tgz",
+      "integrity": "sha512-SZ/fTft5eUhQM6oF/ZaASFDEdbFVe89Imltn9uZr03wdKMcWNVYSMjQPFtg05QuNkt5l5c135ElvXEQG0rk4tw==",
+      "dev": true
+    },
+    "is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "dev": true
     },
     "jest-aws-client-mock": {
       "version": "0.0.24",

--- a/src/app/uitkeringen/package.json
+++ b/src/app/uitkeringen/package.json
@@ -23,7 +23,8 @@
   },
   "devDependencies": {
     "@aws-sdk/types": "3.47.0",
-    "jest-aws-client-mock": "0.0.24",
-    "dotenv": "^16.0.0"
+    "axios-mock-adapter": "^1.20.0",
+    "dotenv": "^16.0.0",
+    "jest-aws-client-mock": "0.0.24"
   }
 }

--- a/src/app/uitkeringen/requestHandler.js
+++ b/src/app/uitkeringen/requestHandler.js
@@ -34,7 +34,7 @@ exports.requestHandler = async (cookies, apiClient, dynamoDBClient) => {
     console.timeLog('request', 'UitkeringsApi');
     const [data, brpData] = await Promise.all([uitkeringsApi.getUitkeringen(bsn), brpApi.getBrpData(bsn)]);
     data.volledigenaam = brpData?.Persoon?.Persoonsgegevens?.Naam ? brpData.Persoon.Persoonsgegevens.Naam : 'Onbekende gebruiker';
-    data.multipleUitkeringen = (data.uitkeringen.length > 1);
+    data.multipleUitkeringen = (data?.uitkeringen?.length > 1);
 
     const html = await renderHtml(data);
 

--- a/src/app/uitkeringen/templates/uitkeringen.mustache
+++ b/src/app/uitkeringen/templates/uitkeringen.mustache
@@ -5,6 +5,7 @@
         <div class="row">
             <div class="col-sm-12">
                 <h1>Mijn Uitkering</h1>
+                {{^error}}
                 <p class="lead">Hier vindt u een overzicht van uw uitkeringen.</p>
                 {{#multipleUitkeringen}}
                     <div class="tabs-wrapper">
@@ -12,7 +13,7 @@
                         <div class="nav classic-tabs-no-line" role="tablist" aria-label="Uitkeringen">
                         {{#uitkeringen}}
                             <div class="nav-item">
-                                <button class="nav-link {{#selected}}active{{/selected}}" role="tab" {{#selected}}aria-selected="true" {{/selected}} aria-controls="{{uitkeringattr}}-tab" id="{{uitkeringattr}}-tabcontrol">
+                                <button class="nav-link {{#selected}}active{{/selected}}" role="tab" {{#selected}}aria-selected="true" {{/selected}} aria-controls="{{typetolower}}-tab" id="{{typetolower}}-tabcontrol">
                                     {{type}}
                                 </button>
                             </div>
@@ -20,7 +21,7 @@
                         </div>
                         {{#uitkeringen}}
                         <!-- Tab Content -->
-                        <div class="tab-content" tabindex="0" role="tabpanel" id="{{uitkeringattr}}-tab" aria-labelledby="{{uitkeringattr}}-tabcontrol">
+                        <div class="tab-content" tabindex="0" role="tabpanel" id="{{typetolower}}-tab" aria-labelledby="{{typetolower}}-tabcontrol">
                             {{> uitkering }}
                         </div>
                         {{/uitkeringen}}
@@ -34,6 +35,11 @@
                 {{^uitkeringen}}
                 <p>U heeft geen lopende uitkeringen.</p>
                 {{/uitkeringen}}
+                {{/error}}
+                {{#error}}
+                    <h2>Er is iets misgegaan</h2>
+                    <p>{{error}}</p>
+                {{/error}}
             </div>
         </div>
     </div>

--- a/src/app/uitkeringen/tests/apiclient.test.ts
+++ b/src/app/uitkeringen/tests/apiclient.test.ts
@@ -1,0 +1,164 @@
+import { SecretsManagerClient, GetSecretValueCommandOutput } from '@aws-sdk/client-secrets-manager';
+import { SSMClient, GetParameterCommandOutput } from '@aws-sdk/client-ssm'; // ES Modules import
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
+import { mockClient } from 'jest-aws-client-mock';
+import { ApiClient } from '../ApiClient';
+
+
+const secretsMock = mockClient(SecretsManagerClient);
+const parameterStoreMock = mockClient(SSMClient);
+const axiosMock = new MockAdapter(axios);
+
+if (process.env.VERBOSETESTS!='True') {
+  global.console.error = jest.fn();
+  global.console.time = jest.fn();
+  global.console.log = jest.fn();
+}
+
+beforeEach(() => {
+  secretsMock.mockReset();
+  parameterStoreMock.mockReset();
+  axiosMock.reset();
+});
+
+describe('Init', () => {
+  test('Init succeeds', async () => {
+    //required env params:
+    process.env.MTLS_PRIVATE_KEY_ARN = 'testarn';
+
+    const secretsOutput: GetSecretValueCommandOutput = {
+      $metadata: {},
+      SecretString: 'test',
+    };
+    secretsMock.mockImplementation(() => secretsOutput);
+    const ssmOutput: GetParameterCommandOutput = {
+      $metadata: {},
+      Parameter: {
+        Value: 'test',
+      },
+    };
+    secretsMock.mockImplementation(() => secretsOutput);
+    parameterStoreMock.mockImplementation(() => ssmOutput);
+
+    const apiClient = new ApiClient();
+    await apiClient.init();
+  });
+
+  test('Error getting secret', async () => {
+    //required env params:
+    process.env.MTLS_PRIVATE_KEY_ARN = 'testarn';
+
+    const secretsOutput: GetSecretValueCommandOutput = {
+      $metadata: {},
+    };
+    secretsMock.mockImplementation(() => secretsOutput);
+    const ssmOutput: GetParameterCommandOutput = {
+      $metadata: {},
+      Parameter: {
+        Value: 'test',
+      },
+    };
+    secretsMock.mockImplementation(() => secretsOutput);
+    parameterStoreMock.mockImplementation(() => ssmOutput);
+
+    const apiClient = new ApiClient();
+    return expect(async () => {
+      return apiClient.init();
+    }).rejects.toThrow();
+  });
+
+  test('Without secret arn fails', async () => {
+    //required env params:
+    process.env.MTLS_PRIVATE_KEY_ARN = 'testarn';
+
+    const secretsOutput: GetSecretValueCommandOutput = {
+      $metadata: {},
+    };
+    secretsMock.mockImplementation(() => secretsOutput);
+    const ssmOutput: GetParameterCommandOutput = {
+      $metadata: {},
+      Parameter: {
+        Value: 'test',
+      },
+    };
+    secretsMock.mockImplementation(() => secretsOutput);
+    parameterStoreMock.mockImplementation(() => ssmOutput);
+
+    const apiClient = new ApiClient();
+    return expect(async () => {
+      return apiClient.init();
+    }).rejects.toThrow();
+  });
+});
+
+describe('Requests', () => {
+  test('Return data', async () => {
+    //required env params:
+    testSetup();
+    const returnData = { users: [{ id: 1, name: 'John Smith' }] };
+    axiosMock.onPost('/test').reply(200, returnData);
+
+    const apiClient = new ApiClient();
+    await apiClient.init();
+    const data = await apiClient.requestData('/test', { data: 'test ' });
+    expect(data).toEqual(returnData);
+  });
+
+  test('Timeout', async () => {
+    //required env params:
+    testSetup();
+    axiosMock.onPost('/test').timeout();
+
+    const apiClient = new ApiClient();
+    await apiClient.init();
+    return expect(async() => {
+      await apiClient.requestData('/test', { data: 'test ' });
+    }).rejects.toThrow();
+    let result: any;
+    try {
+      await apiClient.requestData('/test', { data: 'test ' });
+    } catch (error) {
+      result = error;
+    }
+    expect(result.message).toBe('Het ophalen van gegevens is misgegaan.');
+  });
+
+  test('Network error', async () => {
+    //required env params:
+    testSetup();
+    axiosMock.onPost('/test').networkError();
+
+    const apiClient = new ApiClient();
+    await apiClient.init();
+    return expect(async() => {
+      await apiClient.requestData('/test', { data: 'test ' });
+    }).rejects.toThrow();
+    let result: any;
+    try {
+      await apiClient.requestData('/test', { data: 'test ' });
+    } catch (error) {
+      result = error;
+    }
+    expect(result.message).toBe('Het ophalen van gegevens is misgegaan.');
+  });
+});
+
+function testSetup() {
+  process.env.MTLS_PRIVATE_KEY_ARN = 'testarn';
+
+  const secretsOutput: GetSecretValueCommandOutput = {
+    $metadata: {},
+    SecretString: 'test',
+  };
+  secretsMock.mockImplementation(() => secretsOutput);
+  const ssmOutput: GetParameterCommandOutput = {
+    $metadata: {},
+    Parameter: {
+      Value: 'test',
+    },
+  };
+
+  secretsMock.mockImplementation(() => secretsOutput);
+  parameterStoreMock.mockImplementation(() => ssmOutput);
+}

--- a/src/app/uitkeringen/tests/brp.test.ts
+++ b/src/app/uitkeringen/tests/brp.test.ts
@@ -3,6 +3,12 @@ import { ApiClient } from '../ApiClient';
 import { BrpApi } from '../BrpApi';
 import { FileApiClient } from '../FileApiClient';
 
+if (process.env.VERBOSETESTS!='True') {
+  global.console.error = jest.fn();
+  global.console.time = jest.fn();
+  global.console.log = jest.fn();
+}
+
 
 async function getStringFromFilePath(filePath: string) {
   return new Promise((res, rej) => {
@@ -55,5 +61,5 @@ test('Api', async () => {
   const client = new ApiClient(cert, key, ca);
   const api = new BrpApi(client);
   const result = await api.getBrpData(12345678);
-  expect(result).toBe(false);
+  expect(result).toHaveProperty('error');
 });

--- a/src/app/uitkeringen/tests/uitkering.test.ts
+++ b/src/app/uitkeringen/tests/uitkering.test.ts
@@ -3,10 +3,10 @@ import * as path from 'path';
 import { DynamoDBClient, GetItemCommandOutput } from '@aws-sdk/client-dynamodb';
 import { SecretsManagerClient, GetSecretValueCommandOutput } from '@aws-sdk/client-secrets-manager';
 import { SSMClient, GetParameterCommandOutput } from '@aws-sdk/client-ssm';
-import { mockClient } from 'jest-aws-client-mock';
-import { ApiClient } from '../ApiClient';
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
+import { mockClient } from 'jest-aws-client-mock';
+import { ApiClient } from '../ApiClient';
 import { requestHandler } from '../requestHandler';
 
 beforeAll(() => {
@@ -73,9 +73,9 @@ test('Returns 200', async () => {
   const file = 'uitkering-12345678.xml';
   const filePath = path.join('responses', file);
   const returnData = await getStringFromFilePath(filePath)
-  .then((data: any) => {
-    return data;
-  });
+    .then((data: any) => {
+      return data;
+    });
   axiosMock.onPost().reply(200, returnData);
   const client = new ApiClient();
   const dynamoDBClient = new DynamoDBClient({});
@@ -94,16 +94,15 @@ test('Shows overview page', async () => {
   const file = 'uitkering-12345678.xml';
   const filePath = path.join('responses', file);
   const returnData = await getStringFromFilePath(filePath)
-  .then((data: any) => {
-    return data;
-  });
+    .then((data: any) => {
+      return data;
+    });
   axiosMock.onPost().reply(200, returnData);
   const result = await requestHandler('session=12345', client, dynamoDBClient);
   expect(result.body).toMatch('Mijn Uitkering');
   expect(result.body).toMatch('Participatiewet');
   fs.writeFile(path.join(__dirname, 'output', 'test.html'), result.body, () => {});
 });
-
 
 
 test('Shows two uitkeringen page', async () => {
@@ -117,9 +116,9 @@ test('Shows two uitkeringen page', async () => {
   const file = 'tweeuitkeringen.xml';
   const filePath = path.join('responses', file);
   const returnData = await getStringFromFilePath(filePath)
-  .then((data: any) => {
-    return data;
-  });
+    .then((data: any) => {
+      return data;
+    });
   axiosMock.onPost().reply(200, returnData);
   const result = await requestHandler('session=12345', client, dynamoDBClient);
   expect(result.body).toMatch('Mijn Uitkering');
@@ -139,9 +138,9 @@ test('Shows empty page', async () => {
   const file = 'empty.xml';
   const filePath = path.join('responses', file);
   const returnData = await getStringFromFilePath(filePath)
-  .then((data: any) => {
-    return data;
-  });
+    .then((data: any) => {
+      return data;
+    });
   axiosMock.onPost().reply(200, returnData);
   const result = await requestHandler('session=12345', client, dynamoDBClient);
   expect(result.body).toMatch('Mijn Uitkering');
@@ -158,7 +157,7 @@ test('Shows error page', async () => {
   secretsMock.mockImplementation(() => output);
   const client = new ApiClient();
   const dynamoDBClient = new DynamoDBClient({ region: 'eu-west-1' });
-  
+
   axiosMock.onPost().reply(404);
   const result = await requestHandler('session=12345', client, dynamoDBClient);
   expect(result.body).toMatch('Mijn Uitkering');

--- a/src/app/uitkeringen/tests/uitkering.test.ts
+++ b/src/app/uitkeringen/tests/uitkering.test.ts
@@ -1,9 +1,12 @@
-import { writeFile } from 'fs';
+import * as fs from 'fs';
 import * as path from 'path';
 import { DynamoDBClient, GetItemCommandOutput } from '@aws-sdk/client-dynamodb';
 import { SecretsManagerClient, GetSecretValueCommandOutput } from '@aws-sdk/client-secrets-manager';
+import { SSMClient, GetParameterCommandOutput } from '@aws-sdk/client-ssm';
 import { mockClient } from 'jest-aws-client-mock';
-import { FileApiClient } from '../FileApiClient';
+import { ApiClient } from '../ApiClient';
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
 import { requestHandler } from '../requestHandler';
 
 beforeAll(() => {
@@ -15,15 +18,36 @@ beforeAll(() => {
   process.env.CLIENT_SECRET_ARN = '123';
   process.env.OIDC_CLIENT_ID = '1234';
   process.env.OIDC_SCOPE = 'openid';
+
+  process.env.MTLS_PRIVATE_KEY_ARN = 'testarn';
+
+  const secretsOutput: GetSecretValueCommandOutput = {
+    $metadata: {},
+    SecretString: 'test',
+  };
+  secretsMock.mockImplementation(() => secretsOutput);
+  const ssmOutput: GetParameterCommandOutput = {
+    $metadata: {},
+    Parameter: {
+      Value: 'test',
+    },
+  };
+
+  secretsMock.mockImplementation(() => secretsOutput);
+  parameterStoreMock.mockImplementation(() => ssmOutput);
 });
 
 
 const ddbMock = mockClient(DynamoDBClient);
 const secretsMock = mockClient(SecretsManagerClient);
+const axiosMock = new MockAdapter(axios);
+const parameterStoreMock = mockClient(SSMClient);
 
 beforeEach(() => {
   ddbMock.mockReset();
   secretsMock.mockReset();
+  axiosMock.reset();
+
   const getItemOutput: Partial<GetItemCommandOutput> = {
     Item: {
       loggedin: {
@@ -46,7 +70,14 @@ test('Returns 200', async () => {
     SecretString: 'ditiseennepgeheim',
   };
   secretsMock.mockImplementation(() => output);
-  const client = new FileApiClient();
+  const file = 'uitkering-12345678.xml';
+  const filePath = path.join('responses', file);
+  const returnData = await getStringFromFilePath(filePath)
+  .then((data: any) => {
+    return data;
+  });
+  axiosMock.onPost().reply(200, returnData);
+  const client = new ApiClient();
   const dynamoDBClient = new DynamoDBClient({});
   const result = await requestHandler('session=12345', client, dynamoDBClient);
   expect(result.statusCode).toBe(200);
@@ -58,10 +89,88 @@ test('Shows overview page', async () => {
     SecretString: 'ditiseennepgeheim',
   };
   secretsMock.mockImplementation(() => output);
-  const client = new FileApiClient();
+  const client = new ApiClient();
   const dynamoDBClient = new DynamoDBClient({ region: 'eu-west-1' });
+  const file = 'uitkering-12345678.xml';
+  const filePath = path.join('responses', file);
+  const returnData = await getStringFromFilePath(filePath)
+  .then((data: any) => {
+    return data;
+  });
+  axiosMock.onPost().reply(200, returnData);
   const result = await requestHandler('session=12345', client, dynamoDBClient);
   expect(result.body).toMatch('Mijn Uitkering');
   expect(result.body).toMatch('Participatiewet');
-  writeFile(path.join(__dirname, 'output', 'test.html'), result.body, () => {});
+  fs.writeFile(path.join(__dirname, 'output', 'test.html'), result.body, () => {});
 });
+
+
+
+test('Shows two uitkeringen page', async () => {
+  const output: GetSecretValueCommandOutput = {
+    $metadata: {},
+    SecretString: 'ditiseennepgeheim',
+  };
+  secretsMock.mockImplementation(() => output);
+  const client = new ApiClient();
+  const dynamoDBClient = new DynamoDBClient({ region: 'eu-west-1' });
+  const file = 'tweeuitkeringen.xml';
+  const filePath = path.join('responses', file);
+  const returnData = await getStringFromFilePath(filePath)
+  .then((data: any) => {
+    return data;
+  });
+  axiosMock.onPost().reply(200, returnData);
+  const result = await requestHandler('session=12345', client, dynamoDBClient);
+  expect(result.body).toMatch('Mijn Uitkering');
+  expect(result.body).toMatch('Participatiewet');
+  fs.writeFile(path.join(__dirname, 'output', 'test-twee.html'), result.body, () => {});
+});
+
+
+test('Shows empty page', async () => {
+  const output: GetSecretValueCommandOutput = {
+    $metadata: {},
+    SecretString: 'ditiseennepgeheim',
+  };
+  secretsMock.mockImplementation(() => output);
+  const client = new ApiClient();
+  const dynamoDBClient = new DynamoDBClient({ region: 'eu-west-1' });
+  const file = 'empty.xml';
+  const filePath = path.join('responses', file);
+  const returnData = await getStringFromFilePath(filePath)
+  .then((data: any) => {
+    return data;
+  });
+  axiosMock.onPost().reply(200, returnData);
+  const result = await requestHandler('session=12345', client, dynamoDBClient);
+  expect(result.body).toMatch('Mijn Uitkering');
+  expect(result.body).toMatch('U heeft geen lopende uitkeringen');
+  fs.writeFile(path.join(__dirname, 'output', 'test-empty.html'), result.body, () => {});
+});
+
+
+test('Shows error page', async () => {
+  const output: GetSecretValueCommandOutput = {
+    $metadata: {},
+    SecretString: 'ditiseennepgeheim',
+  };
+  secretsMock.mockImplementation(() => output);
+  const client = new ApiClient();
+  const dynamoDBClient = new DynamoDBClient({ region: 'eu-west-1' });
+  
+  axiosMock.onPost().reply(404);
+  const result = await requestHandler('session=12345', client, dynamoDBClient);
+  expect(result.body).toMatch('Mijn Uitkering');
+  expect(result.body).toMatch('Er is iets misgegaan');
+  fs.writeFile(path.join(__dirname, 'output', 'test-error.html'), result.body, () => {});
+});
+
+async function getStringFromFilePath(filePath: string) {
+  return new Promise((res, rej) => {
+    fs.readFile(path.join(__dirname, filePath), (err, data) => {
+      if (err) {return rej(err);}
+      return res(data.toString());
+    });
+  });
+}

--- a/test/__snapshots__/main.test.ts.snap
+++ b/test/__snapshots__/main.test.ts.snap
@@ -52,7 +52,7 @@ Object {
     },
     \\"build\\": {
       \\"commands\\": [
-        \\"cdk-assets --path \\\\\\"assembly-test-mijn-uitkering-api/testmijnuitkeringapiuitkeringsapi14A41BD4.assets.json\\\\\\" --verbose publish \\\\\\"7449c9d22dd147ce26106385762869324abf34625d0538d5b07fccc22053c4ac:test-eu-west-1\\\\\\"\\"
+        \\"cdk-assets --path \\\\\\"assembly-test-mijn-uitkering-api/testmijnuitkeringapiuitkeringsapi14A41BD4.assets.json\\\\\\" --verbose publish \\\\\\"a5564351c38346214b3f5cdb016d8f1c169a8545819de8dcef2d61fa4fa225d8:test-eu-west-1\\\\\\"\\"
       ]
     }
   }

--- a/test/__snapshots__/main.test.ts.snap
+++ b/test/__snapshots__/main.test.ts.snap
@@ -52,7 +52,7 @@ Object {
     },
     \\"build\\": {
       \\"commands\\": [
-        \\"cdk-assets --path \\\\\\"assembly-test-mijn-uitkering-api/testmijnuitkeringapiuitkeringsapi14A41BD4.assets.json\\\\\\" --verbose publish \\\\\\"a5564351c38346214b3f5cdb016d8f1c169a8545819de8dcef2d61fa4fa225d8:test-eu-west-1\\\\\\"\\"
+        \\"cdk-assets --path \\\\\\"assembly-test-mijn-uitkering-api/testmijnuitkeringapiuitkeringsapi14A41BD4.assets.json\\\\\\" --verbose publish \\\\\\"baa9e236fe030759ea5dafc40af5a5aa43ddc3a78aa7813694442a1a249bdec2:test-eu-west-1\\\\\\"\\"
       ]
     }
   }


### PR DESCRIPTION
Always throw errors from the http api client
Return error messages from the brp api client
Return error messages from the uitkerings api client
Show error message on page if required

Onderdeel van https://github.com/GemeenteNijmegen/mijn-nijmegen/issues/96