### PR TITLE
fix: Close all console.time logs, on error as well as success

### DIFF
--- a/src/app/uitkeringen/ApiClient.js
+++ b/src/app/uitkeringen/ApiClient.js
@@ -84,24 +84,21 @@ class ApiClient {
             console.timeEnd('request to ' + endpoint);
             return response.data;
         } catch (error) {
+            console.timeEnd('request to ' + endpoint);
             if (error.response) {
                 // The request was made and the server responded with a status code
                 // that falls out of the range of 2xx
-                console.timeEnd('request to ' + endpoint);
                 console.log('http status for ' + endpoint + ': ' + error.response.status);
                 
               } else if (error.request) {
                 // The request was made but no response was received
                 // `error.request` is an instance of XMLHttpRequest in the browser and an instance of
                 // http.ClientRequest in node.js
-                console.timeEnd('request to ' + endpoint);
                 console.error(error?.code);
               } else {
                 // Something happened in setting up the request that triggered an Error
-                console.timeEnd('request to ' + endpoint);
                 console.error(error.message);
             }
-            console.timeEnd('request to ' + endpoint);
             throw new Error('Het ophalen van gegevens is misgegaan.');
         }
     }

--- a/test/__snapshots__/main.test.ts.snap
+++ b/test/__snapshots__/main.test.ts.snap
@@ -52,7 +52,7 @@ Object {
     },
     \\"build\\": {
       \\"commands\\": [
-        \\"cdk-assets --path \\\\\\"assembly-test-mijn-uitkering-api/testmijnuitkeringapiuitkeringsapi14A41BD4.assets.json\\\\\\" --verbose publish \\\\\\"0c3eecddcb7949225cb7cb41c3f64e76a0b1bcd27cc1b7756e4ea15a95306c38:test-eu-west-1\\\\\\"\\"
+        \\"cdk-assets --path \\\\\\"assembly-test-mijn-uitkering-api/testmijnuitkeringapiuitkeringsapi14A41BD4.assets.json\\\\\\" --verbose publish \\\\\\"86a96061f111d4667d9704c04de25d3a515cc177d85ee72d4255d7e2a32cf63b:test-eu-west-1\\\\\\"\\"
       ]
     }
   }


### PR DESCRIPTION
Als een lambda-invocation in deze functie niet het happy path volgt, wordt de console.time() niet met een timeEnd() afgesloten. Dat genereert errors in de logging. In deze wijziging wordt ook in het catch block de timeEnd() aangeroepen.