### PR TITLE
fix: params error

### DIFF
--- a/src/app/uitkeringen/tests/uitkering.test.ts
+++ b/src/app/uitkeringen/tests/uitkering.test.ts
@@ -65,117 +65,131 @@ beforeEach(() => {
   ddbMock.mockImplementation(() => getItemOutput);
 });
 
-test('Returns 200', async () => {
-  const output: GetSecretValueCommandOutput = {
-    $metadata: {},
-    SecretString: 'ditiseennepgeheim',
-  };
-  secretsMock.mockImplementation(() => output);
-  const file = 'uitkering-12345678.xml';
-  const filePath = path.join('responses', file);
-  const returnData = await getStringFromFilePath(filePath)
-    .then((data: any) => {
-      return data;
-    });
-  axiosMock.onPost().reply(200, returnData);
+describe('Loading the uitkeringspagina', () => {
 
-  const client = new ApiClient('test', 'test', 'test');
-  const dynamoDBClient = new DynamoDBClient({});
-  const result = await uitkeringsRequestHandler('session=12345', client, dynamoDBClient);
-  expect(result.statusCode).toBe(200);
-});
+  test('Returns 200', async () => {
+    const output: GetSecretValueCommandOutput = {
+      $metadata: {},
+      SecretString: 'ditiseennepgeheim',
+    };
+    secretsMock.mockImplementation(() => output);
+    const file = 'uitkering-12345678.xml';
+    const filePath = path.join('responses', file);
+    const returnData = await getStringFromFilePath(filePath)
+      .then((data: any) => {
+        return data;
+      });
+    axiosMock.onPost().reply(200, returnData);
 
-test('Shows overview page', async () => {
-  const output: GetSecretValueCommandOutput = {
-    $metadata: {},
-    SecretString: 'ditiseennepgeheim',
-  };
-  secretsMock.mockImplementation(() => output);
-
-  const client = new ApiClient('test', 'test', 'test');
-  const dynamoDBClient = new DynamoDBClient({ region: 'eu-west-1' });
-  const file = 'uitkering-12345678.xml';
-  const filePath = path.join('responses', file);
-  const returnData = await getStringFromFilePath(filePath)
-    .then((data: any) => {
-      return data;
-    });
-  axiosMock.onPost().reply(200, returnData);
-  const result = await uitkeringsRequestHandler('session=12345', client, dynamoDBClient);
-  expect(result.body).toMatch('Mijn Uitkering');
-  expect(result.body).toMatch('Participatiewet');
-  fs.writeFile(path.join(__dirname, 'output', 'test.html'), result.body, () => {});
-});
-
-
-test('Shows two uitkeringen page', async () => {
-  const output: GetSecretValueCommandOutput = {
-    $metadata: {},
-    SecretString: 'ditiseennepgeheim',
-  };
-  secretsMock.mockImplementation(() => output);
-
-  const client = new ApiClient('test', 'test', 'test');
-  const dynamoDBClient = new DynamoDBClient({ region: 'eu-west-1' });
-  const file = 'tweeuitkeringen.xml';
-  const filePath = path.join('responses', file);
-  const returnData = await getStringFromFilePath(filePath)
-    .then((data: any) => {
-      return data;
-    });
-  axiosMock.onPost().reply(200, returnData);
-  const result = await uitkeringsRequestHandler('session=12345', client, dynamoDBClient);
-  expect(result.body).toMatch('Mijn Uitkering');
-  expect(result.body).toMatch('Participatiewet');
-  fs.writeFile(path.join(__dirname, 'output', 'test-twee.html'), result.body, () => {});
-});
-
-
-test('Shows empty page', async () => {
-  const output: GetSecretValueCommandOutput = {
-    $metadata: {},
-    SecretString: 'ditiseennepgeheim',
-  };
-  secretsMock.mockImplementation(() => output);
-
-  const client = new ApiClient('test', 'test', 'test');
-  const dynamoDBClient = new DynamoDBClient({ region: 'eu-west-1' });
-  const file = 'empty.xml';
-  const filePath = path.join('responses', file);
-  const returnData = await getStringFromFilePath(filePath)
-    .then((data: any) => {
-      return data;
-    });
-  axiosMock.onPost().reply(200, returnData);
-  const result = await uitkeringsRequestHandler('session=12345', client, dynamoDBClient);
-  expect(result.body).toMatch('Mijn Uitkering');
-  expect(result.body).toMatch('U heeft geen lopende uitkeringen');
-  fs.writeFile(path.join(__dirname, 'output', 'test-empty.html'), result.body, () => {});
-});
-
-
-test('Shows error page', async () => {
-  const output: GetSecretValueCommandOutput = {
-    $metadata: {},
-    SecretString: 'ditiseennepgeheim',
-  };
-  secretsMock.mockImplementation(() => output);
-
-  const client = new ApiClient('test', 'test', 'test');
-  const dynamoDBClient = new DynamoDBClient({ region: 'eu-west-1' });
-
-  axiosMock.onPost().reply(404);
-  const result = await uitkeringsRequestHandler('session=12345', client, dynamoDBClient);
-  expect(result.body).toMatch('Mijn Uitkering');
-  expect(result.body).toMatch('Er is iets misgegaan');
-  fs.writeFile(path.join(__dirname, 'output', 'test-error.html'), result.body, () => {});
-});
-
-async function getStringFromFilePath(filePath: string): Promise<string> {
-  return new Promise((res, rej) => {
-    fs.readFile(path.join(__dirname, filePath), (err, data) => {
-      if (err) {return rej(err);}
-      return res(data.toString());
-    });
+    const client = new ApiClient('test', 'test', 'test');
+    const dynamoDBClient = new DynamoDBClient({});
+    const result = await uitkeringsRequestHandler('session=12345', client, dynamoDBClient);
+    expect(result.statusCode).toBe(200);
   });
-}
+
+  test('Shows overview page', async () => {
+    const output: GetSecretValueCommandOutput = {
+      $metadata: {},
+      SecretString: 'ditiseennepgeheim',
+    };
+    secretsMock.mockImplementation(() => output);
+
+    const client = new ApiClient('test', 'test', 'test');
+    const dynamoDBClient = new DynamoDBClient({ region: 'eu-west-1' });
+    const file = 'uitkering-12345678.xml';
+    const filePath = path.join('responses', file);
+    const returnData = await getStringFromFilePath(filePath)
+      .then((data: any) => {
+        return data;
+      });
+    axiosMock.onPost().reply(200, returnData);
+    const result = await uitkeringsRequestHandler('session=12345', client, dynamoDBClient);
+    expect(result.body).toMatch('Mijn Uitkering');
+    expect(result.body).toMatch('Participatiewet');
+    fs.writeFile(path.join(__dirname, 'output', 'test.html'), result.body, () => {});
+  });
+
+
+  test('Shows two uitkeringen page', async () => {
+    const output: GetSecretValueCommandOutput = {
+      $metadata: {},
+      SecretString: 'ditiseennepgeheim',
+    };
+    secretsMock.mockImplementation(() => output);
+
+    const client = new ApiClient('test', 'test', 'test');
+    const dynamoDBClient = new DynamoDBClient({ region: 'eu-west-1' });
+    const file = 'tweeuitkeringen.xml';
+    const filePath = path.join('responses', file);
+    const returnData = await getStringFromFilePath(filePath)
+      .then((data: any) => {
+        return data;
+      });
+    axiosMock.onPost().reply(200, returnData);
+    const result = await uitkeringsRequestHandler('session=12345', client, dynamoDBClient);
+    expect(result.body).toMatch('Mijn Uitkering');
+    expect(result.body).toMatch('Participatiewet');
+    fs.writeFile(path.join(__dirname, 'output', 'test-twee.html'), result.body, () => {});
+  });
+
+
+  test('Shows empty page', async () => {
+    const output: GetSecretValueCommandOutput = {
+      $metadata: {},
+      SecretString: 'ditiseennepgeheim',
+    };
+    secretsMock.mockImplementation(() => output);
+
+    const client = new ApiClient('test', 'test', 'test');
+    const dynamoDBClient = new DynamoDBClient({ region: 'eu-west-1' });
+    const file = 'empty.xml';
+    const filePath = path.join('responses', file);
+    const returnData = await getStringFromFilePath(filePath)
+      .then((data: any) => {
+        return data;
+      });
+    axiosMock.onPost().reply(200, returnData);
+    const result = await uitkeringsRequestHandler('session=12345', client, dynamoDBClient);
+    expect(result.body).toMatch('Mijn Uitkering');
+    expect(result.body).toMatch('U heeft geen lopende uitkeringen');
+    fs.writeFile(path.join(__dirname, 'output', 'test-empty.html'), result.body, () => {});
+  });
+
+
+  test('Shows error page', async () => {
+    const output: GetSecretValueCommandOutput = {
+      $metadata: {},
+      SecretString: 'ditiseennepgeheim',
+    };
+    secretsMock.mockImplementation(() => output);
+
+    const client = new ApiClient('test', 'test', 'test');
+    const dynamoDBClient = new DynamoDBClient({ region: 'eu-west-1' });
+
+    axiosMock.onPost().reply(404);
+    const result = await uitkeringsRequestHandler('session=12345', client, dynamoDBClient);
+    expect(result.body).toMatch('Mijn Uitkering');
+    expect(result.body).toMatch('Er is iets misgegaan');
+    fs.writeFile(path.join(__dirname, 'output', 'test-error.html'), result.body, () => {});
+  });
+
+  async function getStringFromFilePath(filePath: string): Promise<string> {
+    return new Promise((res, rej) => {
+      fs.readFile(path.join(__dirname, filePath), (err, data) => {
+        if (err) {return rej(err);}
+        return res(data.toString());
+      });
+    });
+  }
+});
+
+describe('Unexpected requests', () => {
+  test('No cookies set should redirect to login page', async() => {
+    const client = new ApiClient('test', 'test', 'test');
+    const dynamoDBClient = new DynamoDBClient({ region: 'eu-west-1' });
+
+    const result = await uitkeringsRequestHandler('', client, dynamoDBClient);
+    expect(result.statusCode).toBe(302);
+    expect(result.headers['Location']).toMatch('/login');
+  });
+});

--- a/src/app/uitkeringen/tests/uitkering.test.ts
+++ b/src/app/uitkeringen/tests/uitkering.test.ts
@@ -190,6 +190,6 @@ describe('Unexpected requests', () => {
 
     const result = await uitkeringsRequestHandler('', client, dynamoDBClient);
     expect(result.statusCode).toBe(302);
-    expect(result.headers['Location']).toMatch('/login');
+    expect(result.headers.Location).toMatch('/login');
   });
 });

--- a/src/app/uitkeringen/uitkeringsRequestHandler.js
+++ b/src/app/uitkeringen/uitkeringsRequestHandler.js
@@ -5,7 +5,7 @@ const { Session } = require('@gemeentenijmegen/session');
 const { Response } = require('@gemeentenijmegen/apigateway-http/lib/V2/Response');
 
 exports.uitkeringsRequestHandler = async (cookies, apiClient, dynamoDBClient) => {
-    if(!cookies || !apiClient || !dynamoDBClient) { throw new Error('all handler params are required'); }
+    if(!apiClient || !dynamoDBClient) { throw new Error('all handler params are required'); }
     console.time('request');
     console.timeLog('request', 'start request');
     

--- a/test/__snapshots__/main.test.ts.snap
+++ b/test/__snapshots__/main.test.ts.snap
@@ -52,7 +52,7 @@ Object {
     },
     \\"build\\": {
       \\"commands\\": [
-        \\"cdk-assets --path \\\\\\"assembly-test-mijn-uitkering-api/testmijnuitkeringapiuitkeringsapi14A41BD4.assets.json\\\\\\" --verbose publish \\\\\\"5e62ec28d3c94d81489e2b108cd7ddba014cf4885f659be8a4b9267a8bf45865:test-eu-west-1\\\\\\"\\"
+        \\"cdk-assets --path \\\\\\"assembly-test-mijn-uitkering-api/testmijnuitkeringapiuitkeringsapi14A41BD4.assets.json\\\\\\" --verbose publish \\\\\\"8f4f67153120f18990a6c85700df2a8764403270a99eb4a7f44b91258cc58c7a:test-eu-west-1\\\\\\"\\"
       ]
     }
   }

--- a/test/__snapshots__/main.test.ts.snap
+++ b/test/__snapshots__/main.test.ts.snap
@@ -52,7 +52,7 @@ Object {
     },
     \\"build\\": {
       \\"commands\\": [
-        \\"cdk-assets --path \\\\\\"assembly-test-mijn-uitkering-api/testmijnuitkeringapiuitkeringsapi14A41BD4.assets.json\\\\\\" --verbose publish \\\\\\"3f3506e9ffacc2e1719d2d2d8c95dc24405a7bdf605765b0fde22765ca411e2b:test-eu-west-1\\\\\\"\\"
+        \\"cdk-assets --path \\\\\\"assembly-test-mijn-uitkering-api/testmijnuitkeringapiuitkeringsapi14A41BD4.assets.json\\\\\\" --verbose publish \\\\\\"5e62ec28d3c94d81489e2b108cd7ddba014cf4885f659be8a4b9267a8bf45865:test-eu-west-1\\\\\\"\\"
       ]
     }
   }


### PR DESCRIPTION
GET requests to this function would fail with http 500 if users were not yet logged in. The session cookie was required in the handler.

This fixes that issue: The cookie is no longer required, if users are not logged in they will be redirected to the login page instead.

Fixes #