### PR TITLE
chore: Comment for overwritten lambda runtime

### DIFF
--- a/src/ApiFunction.ts
+++ b/src/ApiFunction.ts
@@ -27,7 +27,7 @@ export class ApiFunction extends Construct {
     // See https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Lambda-Insights-extension-versionsx86-64.html
     const insightsArn = `arn:aws:lambda:${Stack.of(this).region}:580247275435:layer:LambdaInsightsExtension:21`;
     this.lambda = new props.apiFunction(this, 'lambda', {
-      runtime: Lambda.Runtime.NODEJS_18_X,
+      runtime: Lambda.Runtime.NODEJS_18_X, // Overwritten by projen project type configuration
       memorySize: 512,
       handler: 'index.handler',
       description: props.description,


### PR DESCRIPTION
Lambda runtime config in ApiFunction.ts is overwritten by the projen
 configuration (which is provided by the project type). Fixes #364
